### PR TITLE
Update mrcn_tiny_1x_4n_dp00_lr4.py

### DIFF
--- a/configs/dat/mrcn_tiny_1x_4n_dp00_lr4.py
+++ b/configs/dat/mrcn_tiny_1x_4n_dp00_lr4.py
@@ -5,7 +5,7 @@ _base_ = [
     '../_base_/default_runtime.py'
 ]
 
-pretrained = '<path-to-pretrained-model>'
+load_from = '<path-to-pretrained-model>'
 
 model = dict(
     backbone=dict(
@@ -28,8 +28,7 @@ model = dict(
         use_conv_patches=True,
         ksizes=[9, 7, 5, 3],
         nat_ksizes=[7, 7, 7, 7],
-        drop_path_rate=0.0,
-        init_cfg=dict(type='Pretrained', checkpoint=pretrained)
+        drop_path_rate=0.0
     ),
     neck=dict(in_channels=[64, 128, 256, 512])
 )


### PR DESCRIPTION
Changed the pretrained to load_from because the model checkpoints provided are not weights for the backbone but the entire mode